### PR TITLE
fix: Add smiley back to google search results

### DIFF
--- a/thegreenweb/search-google.js
+++ b/thegreenweb/search-google.js
@@ -38,7 +38,7 @@ $(document).ready(function() {
 
         (function checkLoop() {
             // Check if search results have 'greenweb' link
-            var results = $('#res').find('h3.r > a');
+            var results = $('#res').find('.r > a');
             if ( $('.TGWF').length !== results.length) {
 
                 // Remove all tgwf links


### PR DESCRIPTION
fixes #12 

seems like just a change `h3.r` -> `div.r`

<img width="700" alt="Screenshot 2019-11-25 at 12 17 17" src="https://user-images.githubusercontent.com/1293565/69536208-db222c80-0f7d-11ea-9f13-73754351f72a.png">
