### PR TITLE
fix: Allow tgwf on localized yahoo searches

### DIFF
--- a/thegreenweb/manifest.json
+++ b/thegreenweb/manifest.json
@@ -167,7 +167,7 @@
       "js": ["jquery.min.js", "thegreenweb-utils.js","qtip/jquery.qtip.min.js","search-google.js"]
     },
     {
-      "matches": ["*://search.yahoo.com/*"],
+      "matches": ["*://search.yahoo.com/*", "*://*.search.yahoo.com/*"],
       "js": ["jquery.min.js", "thegreenweb-utils.js","qtip/jquery.qtip.min.js","search-yahoo.js"]
     },
     {


### PR DESCRIPTION
I'm in germany, yahoo redirects my searches to `https://de.search.yahoo.com/search?...`. This PR allows this extension to work on those search results too.