### PR TITLE
20 filter search

### DIFF
--- a/thegreenweb/background.js
+++ b/thegreenweb/background.js
@@ -14,6 +14,7 @@ chrome.runtime.onMessage.addListener(
     if (request.locs){
         doSearchRequest(request.locs,sender.tab);
     }
+    return true;
   }
 );
 

--- a/thegreenweb/background.js
+++ b/thegreenweb/background.js
@@ -120,15 +120,21 @@ function doSearchRequest(data,tab)
  */
 function doApiRequest(sitesUrl, tab)
 {
-    var xhr = new XMLHttpRequest();
-    xhr.open("GET", "https://api.thegreenwebfoundation.org/v2/greencheckmulti/"+sitesUrl, true);
-    xhr.onreadystatechange = function() {
-      if (xhr.readyState === 4) {
-          var resp = JSON.parse(xhr.responseText);
-          chrome.tabs.sendMessage(tab.id, {data: resp}, function(response) {});
-      }
-    }
-    xhr.send();
+    chrome.storage.local.get("tgwf_filter_enabled", function(items) {
+        var filter = false;
+        if (items && items.tgwf_filter_enabled && items.tgwf_filter_enabled === 1) {
+            filter = true;
+        }
+        var xhr = new XMLHttpRequest();
+        xhr.open("GET", "https://api.thegreenwebfoundation.org/v2/greencheckmulti/"+sitesUrl, true);
+        xhr.onreadystatechange = function() {
+            if (xhr.readyState === 4) {
+                var resp = JSON.parse(xhr.responseText);
+                chrome.tabs.sendMessage(tab.id, {data: resp, filter}, function(response) {});
+            }
+        }
+        xhr.send();
+    });
 }
 
 /**

--- a/thegreenweb/background.js
+++ b/thegreenweb/background.js
@@ -120,9 +120,9 @@ function doSearchRequest(data,tab)
  */
 function doApiRequest(sitesUrl, tab)
 {
-    chrome.storage.local.get("tgwf_filter_enabled", function(items) {
+    chrome.storage.sync.get("tgwf_filter_enabled", function(items) {
         var filter = false;
-        if (items && items.tgwf_filter_enabled && items.tgwf_filter_enabled === 1) {
+        if (items && items.tgwf_filter_enabled && items.tgwf_filter_enabled === "1") {
             filter = true;
         }
         var xhr = new XMLHttpRequest();

--- a/thegreenweb/background.js
+++ b/thegreenweb/background.js
@@ -97,6 +97,7 @@ function getGreencheck(url, tabId)
 function doSearchRequest(data,tab)
 {
   var length = Object.keys(data).length;
+  // We ignore sites with more than a 100 urls
   if (length <= 100){
     var sites = Object.getOwnPropertyNames(data).splice(0,50);
     var sitesUrl = JSON.stringify(sites);

--- a/thegreenweb/green-page-links.js
+++ b/thegreenweb/green-page-links.js
@@ -52,8 +52,8 @@ chrome.runtime.onMessage.addListener(
  * If document is ready, find the urls to check
  */
 $(document).ready(function() {
-    chrome.storage.local.get("tgwf_all_disabled", function(items) {
-        if (items && items.tgwf_all_disabled && items.tgwf_all_disabled === 1) {
+    chrome.storage.sync.get("tgwf_all_disabled", function(items) {
+        if (items && items.tgwf_all_disabled && items.tgwf_all_disabled === "1") {
           // Green web search is disabled, return
           return;
         }

--- a/thegreenweb/green-page-links.js
+++ b/thegreenweb/green-page-links.js
@@ -45,6 +45,7 @@ chrome.runtime.onMessage.addListener(
               }
             });
         }
+        return true;
     });
 
 /**

--- a/thegreenweb/manifest.json
+++ b/thegreenweb/manifest.json
@@ -3,17 +3,14 @@
   "update_url":"http://clients2.google.com/service/update2/crx",
   "name": "The Green Web",
   "short_name": "The Green Web",
-  "version": "2.1.4",
+  "version": "2.2.0",
   "description": "Automatically check the sustainability of a website with The Green Web add-on.",
   "background": {
     "scripts": ["background.js","thegreenweb-utils.js","tracker.js"],
     "persistent": false
   },
   "minimum_chrome_version" : "22",
-  "options_ui": {
-    "page": "options.html",
-    "chrome_style": true
-  },
+  "options_page": "options.html",
   "offline_enabled": false,
   "content_security_policy": "script-src 'self'; object-src 'self';",
   "icons": {

--- a/thegreenweb/options.html
+++ b/thegreenweb/options.html
@@ -20,8 +20,8 @@
 			<div id='filter' class="well">
 			<h3>The Green Web Ethical filter:</h3>
 			<p>If you enable the green web search, you can also enable filtering, meaning that any grey results will not be shown anymore.</p>
-			<input type='radio' name='filter' id='filteron' value='1' checked='checked' />Enabled<br/>
-			<input type='radio' name='filter' id='filteroff' value='0'/>Disabled<br/>
+			<input type='radio' name='filter' id='filteron' value='1'  />Enabled<br/>
+			<input type='radio' name='filter' id='filteroff' value='0'  checked='checked'/>Disabled<br/>
 			<br/>
 			<div class='alert' style="background-color: yellow;">Reload search pages for this setting to take effect. </div>
 			</div>

--- a/thegreenweb/options.html
+++ b/thegreenweb/options.html
@@ -16,6 +16,15 @@
 			<br/>
 			<div class='alert' style="background-color: yellow;">Reload search pages for this setting to take effect. </div>
 			</div>
+
+			<div id='filter' class="well">
+			<h3>The Green Web Ethical filter:</h3>
+			<p>If you enable the green web search, you can also enable filtering, meaning that any grey results will not be shown anymore.</p>
+			<input type='radio' name='filter' id='filteron' value='1' checked='checked' />Enabled<br/>
+			<input type='radio' name='filter' id='filteroff' value='0'/>Disabled<br/>
+			<br/>
+			<div class='alert' style="background-color: yellow;">Reload search pages for this setting to take effect. </div>
+			</div>
 			
 			<div id='alllinks' class="well">
 			<h3>The Green Web for all external links:</h3>

--- a/thegreenweb/options.js
+++ b/thegreenweb/options.js
@@ -24,7 +24,14 @@ function save_options() {
     allvalue = 0;
   }
 
-  chrome.storage.local.set( {'tgwf_search_disabled' : value, 'tgwf_all_disabled': allvalue} , function() {
+  // Defaults to off, no filtering of search results
+  var filteron = $('#filteron').attr('checked');
+  var filtervalue = 0;
+  if (filteron === 'checked') {
+    filtervalue = 1;
+  }
+
+  chrome.storage.local.set( {'tgwf_search_disabled' : value, 'tgwf_all_disabled': allvalue, 'tgwf_filter_enabled': filtervalue} , function() {
       // Update status to let user know options were saved.
     var status = document.getElementById("status");
     var newDiv = document.createElement("div");
@@ -61,6 +68,15 @@ function restore_options() {
       $('#alloff').attr('checked','checked');
     } else {
       $('#allon').attr('checked','checked');
+    }
+  });
+  chrome.storage.local.get("tgwf_filter_enabled", function(items) {
+    var enable = items.tgwf_filter_enabled;
+    // 1 is disabled, 0 or not set is enabled
+    if (enable === 1) {
+      $('#filteron').attr('checked','checked');
+    } else {
+      $('#filteroff').attr('checked','checked');
     }
   });
 }

--- a/thegreenweb/options.js
+++ b/thegreenweb/options.js
@@ -12,26 +12,42 @@
  * 1 = search disabled
  */
 function save_options() {
-  var search = $('#searchon').attr('checked');
+  var radios = document.getElementsByName('search');
   var value = 1;
-  if (search === 'checked') {
-    value = 0;
+  for (var i = 0, length = radios.length; i < length; i++) {
+    if (radios[i].checked) {
+      value = radios[i].value;
+
+      // only one radio can be logically checked, don't check the rest
+      break;
+    }
   }
 
-  var allon = $('#allon').attr('checked');
+  radios = document.getElementsByName('all');
   var allvalue = 1;
-  if (allon === 'checked') {
-    allvalue = 0;
+  for (var i = 0, length = radios.length; i < length; i++) {
+    if (radios[i].checked) {
+      allvalue = radios[i].value;
+
+      // only one radio can be logically checked, don't check the rest
+      break;
+    }
   }
 
-  // Defaults to off, no filtering of search results
-  var filteron = $('#filteron').attr('checked');
-  var filtervalue = 0;
-  if (filteron === 'checked') {
-    filtervalue = 1;
+  radios = document.getElementsByName('filter');
+  var filtervalue = 1;
+  for (var i = 0, length = radios.length; i < length; i++) {
+    if (radios[i].checked) {
+      // do whatever you want with the checked radio
+      filtervalue = radios[i].value;
+
+      // only one radio can be logically checked, don't check the rest
+      break;
+    }
   }
 
-  chrome.storage.local.set( {'tgwf_search_disabled' : value, 'tgwf_all_disabled': allvalue, 'tgwf_filter_enabled': filtervalue} , function() {
+  chrome.storage.sync.set( {'tgwf_search_disabled' : value, 'tgwf_all_disabled': allvalue, 'tgwf_filter_enabled': filtervalue} ,
+      function() {
       // Update status to let user know options were saved.
     var status = document.getElementById("status");
     var newDiv = document.createElement("div");
@@ -41,7 +57,7 @@ function save_options() {
     status.appendChild(newDiv);
     setTimeout(function() {
       status.textContent = "";;
-    }, 1500);
+    }, 15000);
   })  
   
 }
@@ -52,28 +68,28 @@ function save_options() {
  * 1 = search disabled
  */
 function restore_options() {
-  chrome.storage.local.get("tgwf_search_disabled", function(items) {
+  chrome.storage.sync.get("tgwf_search_disabled", function(items) {
     var disable = items.tgwf_search_disabled;
     // 1 is disabled, 0 or not set is enabled
-    if (disable === 1) {
+    if (disable === "1") {
       $('#searchoff').attr('checked','checked');
     } else {
       $('#searchon').attr('checked','checked');
     }
   });
-  chrome.storage.local.get("tgwf_all_disabled", function(items) {
+  chrome.storage.sync.get("tgwf_all_disabled", function(items) {
     var disable = items.tgwf_all_disabled;
     // 1 is disabled, 0 or not set is enabled
-    if (disable === 1) {
+    if (disable === "1") {
       $('#alloff').attr('checked','checked');
     } else {
       $('#allon').attr('checked','checked');
     }
   });
-  chrome.storage.local.get("tgwf_filter_enabled", function(items) {
+  chrome.storage.sync.get("tgwf_filter_enabled", function(items) {
     var enable = items.tgwf_filter_enabled;
     // 1 is disabled, 0 or not set is enabled
-    if (enable === 1) {
+    if (enable === "1") {
       $('#filteron').attr('checked','checked');
     } else {
       $('#filteroff').attr('checked','checked');

--- a/thegreenweb/search-bing.js
+++ b/thegreenweb/search-bing.js
@@ -43,8 +43,8 @@ chrome.runtime.onMessage.addListener(
  * If document is ready, find the urls to check
  */
 $(document).ready(function() {
-    chrome.storage.local.get("tgwf_search_disabled", function(items) {
-        if (items && items.tgwf_search_disabled && items.tgwf_search_disabled == 1) {
+    chrome.storage.sync.get("tgwf_search_disabled", function(items) {
+        if (items && items.tgwf_search_disabled && items.tgwf_search_disabled === "1") {
           // Green web search is disabled, return
           return;
         }

--- a/thegreenweb/search-bing.js
+++ b/thegreenweb/search-bing.js
@@ -36,6 +36,7 @@ chrome.runtime.onMessage.addListener(
                 }
             });
         }
+        return true;
     });
 
 /**

--- a/thegreenweb/search-bing.js
+++ b/thegreenweb/search-bing.js
@@ -32,7 +32,11 @@ chrome.runtime.onMessage.addListener(
                         $(this).find('.TGWF').first().qtip('option', { 'style.classes': 'qtip-green'});
                       } else {
                         $(this).find('.TGWF').first().qtip('option', { 'style.classes': 'qtip-light'});
-                      }                
+                      }
+                      if(request.filter && data[loc].green === false) {
+                        // remove full result from the page
+                        $(this).hide();
+                    }
                 }
             });
         }

--- a/thegreenweb/search-ecosia.js
+++ b/thegreenweb/search-ecosia.js
@@ -43,8 +43,8 @@ chrome.runtime.onMessage.addListener(
  * If document is ready, find the urls to check
  */
 $(document).ready(function() {
-    chrome.storage.local.get("tgwf_search_disabled", function(items) {
-        if (items && items.tgwf_search_disabled && items.tgwf_search_disabled === 1) {
+    chrome.storage.sync.get("tgwf_search_disabled", function(items) {
+        if (items && items.tgwf_search_disabled && items.tgwf_search_disabled === "1") {
           // Green web search is disabled, return
           return;
         }

--- a/thegreenweb/search-ecosia.js
+++ b/thegreenweb/search-ecosia.js
@@ -36,6 +36,7 @@ chrome.runtime.onMessage.addListener(
                 }
             });
         }
+        return true;
     });
 
 /**

--- a/thegreenweb/search-ecosia.js
+++ b/thegreenweb/search-ecosia.js
@@ -32,7 +32,11 @@ chrome.runtime.onMessage.addListener(
                         $(this).find('.TGWF').first().qtip('option', { 'style.classes': 'qtip-green'});
                       } else {
                         $(this).find('.TGWF').first().qtip('option', { 'style.classes': 'qtip-light'});
-                      }                
+                      }
+                    if(request.filter && data[loc].green === false) {
+                        // remove full result from the page
+                        $(this).hide();
+                    }
                 }
             });
         }

--- a/thegreenweb/search-google.js
+++ b/thegreenweb/search-google.js
@@ -12,6 +12,7 @@ chrome.runtime.onMessage.addListener(
     function(request, sender, sendResponse) {
         if (request.data){
             var data = request.data;
+            console.log(request.filter);
             
             var links = $('.TGWF');
             $(links).each(function () {

--- a/thegreenweb/search-google.js
+++ b/thegreenweb/search-google.js
@@ -21,6 +21,7 @@ chrome.runtime.onMessage.addListener(
                 }
             });
         }
+        return true;
     });
 
 /**

--- a/thegreenweb/search-google.js
+++ b/thegreenweb/search-google.js
@@ -29,8 +29,8 @@ chrome.runtime.onMessage.addListener(
  * If document is ready, find the urls to check
  */
 $(document).ready(function() {
-    chrome.storage.local.get("tgwf_search_disabled", function(items) {
-        if (items && items.tgwf_search_disabled && items.tgwf_search_disabled === 1) {
+    chrome.storage.sync.get("tgwf_search_disabled", function(items) {
+        if (items && items.tgwf_search_disabled && items.tgwf_search_disabled === "1") {
           // Green web search is disabled, return
           return;
         }

--- a/thegreenweb/search-google.js
+++ b/thegreenweb/search-google.js
@@ -12,13 +12,15 @@ chrome.runtime.onMessage.addListener(
     function(request, sender, sendResponse) {
         if (request.data){
             var data = request.data;
-            console.log(request.filter);
-            
             var links = $('.TGWF');
             $(links).each(function () {
                 var loc = getUrl($(this).parent().attr('href'));
                 if (data[loc]) {
                     $(this).html(getResultNode(data[loc], 'google').append('&nbsp;'));
+                    if(request.filter && data[loc].green === false) {
+                        // remove full result from the page
+                        $(this).parents('.rc').hide();
+                    }
                 }
             });
         }

--- a/thegreenweb/search-yahoo.js
+++ b/thegreenweb/search-yahoo.js
@@ -43,8 +43,8 @@ chrome.runtime.onMessage.addListener(
  * If document is ready, find the urls to check
  */
 $(document).ready(function() {
-    chrome.storage.local.get("tgwf_search_disabled", function(items) {
-        if (items && items.tgwf_search_disabled && items.tgwf_search_disabled === 1) {
+    chrome.storage.sync.get("tgwf_search_disabled", function(items) {
+        if (items && items.tgwf_search_disabled && items.tgwf_search_disabled === "1") {
           // Green web search is disabled, return
           return;
         }

--- a/thegreenweb/search-yahoo.js
+++ b/thegreenweb/search-yahoo.js
@@ -36,6 +36,7 @@ chrome.runtime.onMessage.addListener(
                 }
             });
         }
+        return true;
     });
 
 /**

--- a/thegreenweb/search-yahoo.js
+++ b/thegreenweb/search-yahoo.js
@@ -32,7 +32,11 @@ chrome.runtime.onMessage.addListener(
                     $(this).find('.TGWF').first().qtip('option', { 'style.classes': 'qtip-green'});
                   } else {
                     $(this).find('.TGWF').first().qtip('option', { 'style.classes': 'qtip-light'});
-                  }                
+                  }
+                    if(request.filter && data[loc].green === false) {
+                        // remove full result from the page
+                        $(this).hide();
+                    }
                 }
             });
         }


### PR DESCRIPTION
This pull request adds ethical filtering to the web extension, like we have done for the searx plugin we created. 

On the options page there is now an ethical filtering option. It's disabled by default. On enabling, assuming you have the search option enabled, the results on the different search engines the extension supports will be filtered if they are grey. In those cases the whole results row on the page will disappear instead of showing the result with a grey smiley. 

I have also fixed a few other smaller issues and the storing/restoring of the options as that seemed to have broken. 