### PR TITLE
fix URL permission in manifest.json

### DIFF
--- a/thegreenweb/manifest.json
+++ b/thegreenweb/manifest.json
@@ -51,7 +51,6 @@
   "content_scripts": [
    {
       "matches": [
-            "*://*.duckduckgo.com/*",
             "*://*.google.com/*",
             "*://*.google.it/*",
             "*://*.google.com.tr/*",

--- a/thegreenweb/manifest.json
+++ b/thegreenweb/manifest.json
@@ -42,8 +42,8 @@
     "images/top-logo-greenweb.png"
   ],
   "permissions": [
-        "https://api.thegreenwebfoundation.org",
-        "https://www.thegreenwebfoundation.org",
+        "*://api.thegreenwebfoundation.org/*",
+        "*://www.thegreenwebfoundation.org/*",
         "webNavigation",
         "tabs",
         "storage"
@@ -51,6 +51,7 @@
   "content_scripts": [
    {
       "matches": [
+            "*://*.duckduckgo.com/*",
             "*://*.google.com/*",
             "*://*.google.it/*",
             "*://*.google.com.tr/*",


### PR DESCRIPTION
I managed to load the addon via the `addon:debugging` page.

I saw an error with the privileges:
![image](https://user-images.githubusercontent.com/44118972/108890287-ad5ae600-760d-11eb-88e1-4fd9ad8c4e1a.png)

After changing the related lines in the `manigest.json` to make it fit with the required pattern, the error is not occurring anymore.